### PR TITLE
Created permissions() method to return an array of all permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ $user->hasRole(string $role) : bool
 // Access all permissions for a given role belonging to the user...
 $user->rolePermissions(string $role) : ?array
 
+// Return all permissions belonging to the user...
+$user->permissions() : array
+
 // Determine if the user role has a given permission...
 $user->hasRolePermission(string $role, string $permission) : bool
 

--- a/src/HasRoles.php
+++ b/src/HasRoles.php
@@ -45,7 +45,15 @@ trait HasRoles
     public function hasPermission(string $permission): bool
     {
         return $this->roles
-            ->map(fn ($userRole) => $this->hasRolePermission($userRole->role, $permission))
+            ->map(fn($userRole) => $this->hasRolePermission($userRole->role, $permission))
             ->containsStrict(true);
     }
+
+    public function permissions(): array
+    {
+        return $this->roles
+            ->map(fn($userRole) => $this->findRole($userRole)?->permissions)
+            ->filter()->flatten()->unique()->toArray();
+    }
+
 }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -113,4 +113,30 @@ class HasRolesTest extends OrchestraTestCase
 
         $this->assertTrue($user->hasPermission('post:create'));
     }
+
+    public function test_permissions_returns_array_of_assigned_permissions()
+    {
+        $role = Ladder::role('admin', 'Admin', [
+            'read',
+            'create',
+            'update',
+            'delete',
+        ])->description('Some admin description');
+
+        $role = Ladder::role('editor', 'Editor', [
+            'read',
+            'create',
+            'update',
+        ])->description('Some editor description');
+
+        $user = User::factory()
+            ->has(UserRole::factory(['role' => 'admin']), 'roles')
+            ->has(UserRole::factory(['role' => 'editor']), 'roles')
+            ->has(UserRole::factory(['role' => 'unknown']), 'roles') // should be ignored
+            ->create();
+
+        $this->assertEquals(['read', 'create', 'update', 'delete'], $user->permissions());
+    }
+
+
 }


### PR DESCRIPTION
I saw this package had been released on Laravel News and thought it certainly has its place over packages that I've used such as Spatie's laravel-permissions, my usual go-to. So thanks for releasing it!

We're using it in a project that has a Vue frontend, and the simple ability to pull an array of all permissions assigned to the user seemed like a useful feature.

Hope you can see the user for it :)

