### PR TITLE
Package bumps to Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,12 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [10]
+        laravel: [10,11]
+        stability: [prefer-stable]
+        exclude:
+          # Laravel 11 doesn't support PHP 8.1
+          - laravel: 11
+            php: 8.1
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
@@ -29,7 +34,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/contracts=^${{ matrix.laravel }}" --dev --no-update
+          composer require "laravel/framework=^${{ matrix.laravel }}" --dev --no-update
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea/
 /vendor/
 .phpunit.result.cache
+.phpunit.cache
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,12 @@
   "require": {
     "php": "^8.1",
     "ext-json": "*",
-    "illuminate/console": "^10.0",
-    "illuminate/support": "^10.0"
+    "laravel/framework": "^10.0|^11.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.0",
-    "orchestra/testbench": "^8.0",
-    "phpunit/phpunit": "^9.0"
+    "orchestra/testbench": "^8.0|^9.0",
+    "phpunit/phpunit": "^9.0|^10.5|^11.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertDeprecationsToExceptions="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
->
-    <testsuites>
-        <testsuite name="Ladder Test Suite">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <server name="APP_KEY" value="yqTzObeFpDe5NHTCEwdu17j2fTcbbALQ"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Ladder Test Suite">
+      <directory suffix="Test.php">./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <server name="APP_KEY" value="yqTzObeFpDe5NHTCEwdu17j2fTcbbALQ"/>
+  </php>
 </phpunit>


### PR DESCRIPTION
Added support and matrix tests for Laravel 11.

Dependency changes to require the entire laravel/framework rather than individual illuminate components