### PR TITLE
Removed end of life laravel version support (10 & 11) and php 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,16 +11,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [10, 11, 12, 13]
-        stability: [prefer-stable]
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: [12, 13]
         exclude:
-          - laravel: 11
-            php: 8.1
-          - laravel: 12
-            php: 8.1
-          - laravel: 13
-            php: 8.1
           - laravel: 13
             php: 8.2
 
@@ -41,7 +34,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework=^${{ matrix.laravel }}" --dev --no-update
+          composer require "laravel/framework=^${{ matrix.laravel }}" --dev --no-update --prefer-stable
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Inspired by [Laravel Jetstream](https://jetstream.laravel.com/features/teams.htm
 it offers a static approach, reducing queries and ensuring immutability for easy modifications.
 
 ## Install
-> This package requires Laravel 10 and above.
+> This package requires Laravel 12 and above.
 ```bash
 composer require eneadm/ladder
 ```

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
-        "laravel/framework": "^10.0|^11.0|^12.0|^13.0"
+        "laravel/framework": "^12.0|^13.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
-        "phpunit/phpunit": "^9.0|^10.5|^11.0|^12"
+        "mockery/mockery": "^1.4",
+        "orchestra/testbench": "^10.0|^11.0",
+        "phpunit/phpunit": "^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^10.0|^11.0",
-        "phpunit/phpunit": "^12.0"
+        "phpunit/phpunit": "^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since laravel dropped support for laravel 10 and 11 we are forced to drop support for it as well. Dependabot already reported high alerts for security issues regarding these old versions: https://github.com/eneadm/ladder/security/dependabot/4

Now this package supports laravel 12+ and php 8.2+